### PR TITLE
use common gh action and setup automatic release note generation from PR

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,2 @@
+_extends: .github
+tag-template: jetty-xhtml-schemas-$NEXT_MINOR_VERSION

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,51 +1,12 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
-name: GitHub CI
+name: Verify
 
 on:
   push:
-    branches:
-      - 'master'
-      - 'main'
   pull_request:
 
 jobs:
   build:
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        java: [11]
-        jdk: [temurin]
-      fail-fast: false
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: ${{ matrix.jdk }}
-          java-version: ${{ matrix.java }}
-          cache: 'maven'
-
-      - name: Build with Maven
-        run: mvn install javadoc:javadoc -e -B -V
+    name: Verify
+    uses: jetty/.github/.github/workflows/maven-ci.yml@main
+    with:
+      jdk-matrix: '[ "11" ]'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,12 @@
+name: Release Drafter
+on:
+  push:
+    branches:
+      - master
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
re use an existing gh action with changing parmeters if needed.
setup release drafter to generate release notes from PRs see example here https://github.com/jetty/jetty.setuid/releases